### PR TITLE
Add codesandbox demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ npm install --save vue-json-schema
 ```
 
 ## Demo
-- [Demo with ElementUI](https://github.com/demsking/vue-json-schema-demo-elementui)
+- [Demo Repository with ElementUI](https://github.com/demsking/vue-json-schema-demo-elementui)
+- [Codesanbox demo with ElementUI](https://codesandbox.io/s/mjpv57kjwx)
 
 ## FormSchema API
 


### PR DESCRIPTION
I added a codesandbox demo based on your repository demo.
People usually like demos then can open online. 
Codesandbox has an option to sync from a repository and the added demo will sync with the github repo whenever it's changed