### PR TITLE
Fix parser.js

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -15,7 +15,7 @@ const setCommonFields = (schema, field) => {
 }
 
 const setFormValue = (vm, field) => {
-  if (vm.value && !vm.value[field.name]) {
+  if (vm.value && (!vm.value[field.name] && typeof(vm.value[field.name]) !== "number")) {
     vm.$set(vm.value, field.name, field.value)
   }
 }


### PR DESCRIPTION
Hi,

I found a bug when i make a form with input[type=number] and read data from backend which has 0 as value. Editing a product form with price field which is free (price = 0) cause validation error (price field is required by backend validation).

Before
![zrzut ekranu 2017-12-29 o 14 13 49](https://user-images.githubusercontent.com/231734/34437915-f92d8652-eca2-11e7-9494-cfe5997e0291.png)

After
![zrzut ekranu 2017-12-29 o 14 14 27](https://user-images.githubusercontent.com/231734/34437920-017b9cd6-eca3-11e7-85b7-4a0ef828ef0b.png)
