### PR TITLE
Adds nested schema attributes support with dot notation (v2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
     "vue-template-compiler": "^2.5.13",
     "webpack": "^3.10.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "lodash": "^4.17.10"
+  },
   "jest": {
     "collectCoverage": true,
     "collectCoverageFrom": [

--- a/test/specs/components.spec.js
+++ b/test/specs/components.spec.js
@@ -1,11 +1,15 @@
 'use strict'
 
+import _ from 'lodash'
+
 import {
   init,
   option,
   components,
   elementOptions,
-  defineComponent
+  defineComponent,
+  initObjectAttribute,
+  initFields
 } from '../../src/lib/components'
 
 /* global describe it expect beforeEach */
@@ -179,5 +183,56 @@ describe('lib/components', () => {
 
       expect(elementOptions(vm, el, {}, field)).toEqual(expected)
     })
+  })
+
+  describe('initObjectAttribute => init data object for nested attributes', () => {
+    let value = {
+      test: 'test data',
+      nested: {
+        var: 'test var'
+      }
+    }
+    let data = {}
+    let schema = {
+      'test': {},
+      'nested.var': {}
+    }
+
+    // init the data getter-setter
+    Object.keys(schema).forEach((key) => {
+      initObjectAttribute(data, key)
+      data[key] = _.get(value, key)
+    })
+
+    expect(data['test']).toEqual('test data')
+    expect(data['nested.var']).toEqual('test var')
+  })
+
+  describe('initFields', () => {
+    let value = {
+      test: 'test data',
+      nested: {
+        var: 'test var'
+      }
+    }
+    let data = {}
+    let fields = [
+      { attrs: {name: 'test'} },
+      { attrs: {name: 'nested.var'} }
+    ]
+
+    const vm = {
+      value,
+      data,
+      fields,
+      default: {},
+      $emit () {}
+    }
+
+    initFields(vm)
+
+    expect(vm.data['test']).toEqual('test data')
+    expect(vm.data['nested.var']).toEqual('test var')
+    expect(vm.default['nested.var']).toEqual('test var')
   })
 })


### PR DESCRIPTION
This code change allows schema definition with dot notation for nested data values.

```
{
    "$schema": "http://json-schema.org/draft-04/schema#",
    "type": "object",
    "properties": {
        "business_name": {
            "type": "string", 
            "minLength": 8, 
            "maxLength": 80, 
            "attrs": {
                "placeholder": "User Email"
            }
        },
        "user.email": {
            "type": "string", 
            "minLength": 8, 
            "maxLength": 80, 
            "attrs": {
                "placeholder": "User Email"
            }
        },
        "user.name": {
            "type": "string", 
            "minLength": 8, 
            "maxLength": 80, 
            "attrs": {
                "placeholder": "User First and Second Name"
            }
        },
    },
    "additionalProperties": false,
    "required": ["name", "email", "password", "termsAccepted"]
}
```

this schema to work on a dataset like this

```
{
    "business_name": "ACME",
    "user": {
        "name": "Jon Doe",
        "email": "jon@acme.us"
    },
}
```